### PR TITLE
fix: use the correct amount of spaces

### DIFF
--- a/xjson/write.go
+++ b/xjson/write.go
@@ -10,7 +10,7 @@ import (
 // PrettyPrintJSON pretty prints JSON
 func PrettyPrintJSON(body []byte, writer io.Writer) error {
 	var prettyJSON bytes.Buffer
-	err := json.Indent(&prettyJSON, body, "", "  ")
+	err := json.Indent(&prettyJSON, body, "", "    ")
 	if err != nil {
 		return err
 	}

--- a/xjson/write_test.go
+++ b/xjson/write_test.go
@@ -10,7 +10,7 @@ import (
 func TestPrettyPrintJSON(t *testing.T) {
 	t.Run("valid JSON", func(t *testing.T) {
 		input := []byte(`{"name": "John", "age": 30}`)
-		expected := "{\n  \"name\": \"John\",\n  \"age\": 30\n}\n"
+		expected := "{\n    \"name\": \"John\",\n    \"age\": 30\n}\n"
 		var output bytes.Buffer
 		err := PrettyPrintJSON(input, &output)
 		assert.NoError(t, err)


### PR DESCRIPTION
BREAKING: pretty json printing is now 4 (four) spaces