### PR TITLE
feat(xstructs): custom tags

### DIFF
--- a/xstructs/map.go
+++ b/xstructs/map.go
@@ -114,7 +114,7 @@ func (h *handler) handle(obj any) any {
 }
 
 // handleStruct handles the conversion of a struct to a map[string]any.
-// It uses the "json" and "yaml" tags to determine the key names.
+// It uses the tags from the handler to determine the key names.
 func (h *handler) handleStruct(obj any) any {
 	res := map[string]any{}
 	val := reflect.ValueOf(obj)
@@ -222,16 +222,16 @@ func (h *handler) handleSlice(obj any) any {
 }
 
 // getTag retrieves the tag name and options from a struct field.
-// It checks for the "json" and "yaml" tags in that order.
+// It checks the tags provided by the handler one by one.
 // If one tag is empty, it will return the other tag.
-// If both tags are empty, it returns an empty string and an empty slice.
+// If all tags are empty, it returns an error.
 func (h *handler) getTag(field reflect.StructField) (*tagWrapper, error) {
 	for _, category := range h.tags {
 		if tag := field.Tag.Get(category); tag != "" {
 			splitTag := strings.Split(tag, ",")
 			// Test if tag is solitary comma, i.e. `json:","`
 			if splitTag[0] == "" && len(splitTag[1]) == 0 {
-				return nil, fmt.Errorf("no tag of %s found for field %s", strings.Join(h.tags, ", "), field.Name)
+				continue
 			}
 			return &tagWrapper{
 				Name:    splitTag[0],

--- a/xstructs/map.go
+++ b/xstructs/map.go
@@ -11,21 +11,52 @@ import (
 // tagCategories is a list of tag categories to check for.
 var tagCategories = []string{"json", "yaml"}
 
-func WithTags(tags ...string) toMapOptions {
+// WithTags allows you to specify custom tag categories to check for.
+// It can be used to override the default "json" and "yaml" tags.
+// The tags are checked in the order they are provided.
+func WithTags(tags ...string) ToMapOptions {
 	return func(h *handler) {
 		h.tags = tags
 	}
 }
 
-type toMapOptions func(*handler)
-
-type handler struct {
-	tags []string
+// WithAllowNoTags allows you to specify whether to allow fields without tags.
+// If used, fields without tags will be included in the output map.
+func WithAllowNoTags() ToMapOptions {
+	return func(h *handler) {
+		h.allowNoTags = true
+	}
 }
 
-func newHandler(opts ...toMapOptions) *handler {
+// ToMapOptions is a function that modifies the handler.
+type ToMapOptions func(*handler)
+
+// handler is a struct that contains the options for the ToMap function.
+// It contains a list of tags to check for and a flag to allow fields
+// without tags.
+type handler struct {
+	tags        []string
+	allowNoTags bool
+}
+
+// tagWrapper is a struct that contains the name and options of a tag.
+// It is used to store the tag information for a field.
+// The name is the key name to use in the output map.
+// The options are the options specified in the tag.
+type tagWrapper struct {
+	Name    string
+	Options []string
+}
+
+// newHandler creates a new handler with the default options.
+// It initializes the tags to the default "json" and "yaml" tags.
+// It also initializes the allowNoTags flag to false.
+// It can be modified using the ToMapOptions functions.
+// It returns a pointer to the handler.
+func newHandler(opts ...ToMapOptions) *handler {
 	h := &handler{
-		tags: tagCategories,
+		tags:        tagCategories,
+		allowNoTags: false,
 	}
 
 	for _, opt := range opts {
@@ -44,7 +75,7 @@ func newHandler(opts ...toMapOptions) *handler {
 //
 // If the input is nil, it returns nil.
 // If the input is not a struct or map, it returns an error.
-func ToMap(obj any, opts ...toMapOptions) (map[string]any, error) {
+func ToMap(obj any, opts ...ToMapOptions) (map[string]any, error) {
 	handler := newHandler(opts...)
 
 	if obj == nil {
@@ -100,19 +131,30 @@ func (h *handler) handleStruct(obj any) any {
 
 		name := field.Name
 		value := val.Field(i)
-		tagName, tagOpts := h.getTag(field)
-		if tagName != "" {
-			name = tagName
-		}
-
-		// Omit struct tag "-"
-		if _, ok := xslices.FindFunc(tagOpts, func(s string) bool {
-			return s == "-"
-		}); ok || (name == "-" && len(tagOpts) == 0) {
+		tagInfo, err := h.getTag(field)
+		if err != nil && !h.allowNoTags {
 			continue
 		}
 
-		if _, ok := xslices.FindFunc(tagOpts, func(s string) bool {
+		if h.allowNoTags && tagInfo == nil {
+			tagInfo = &tagWrapper{
+				Name:    "",
+				Options: []string{},
+			}
+		}
+
+		if tagInfo.Name != "" {
+			name = tagInfo.Name
+		}
+
+		// Omit struct tag "-"
+		if _, ok := xslices.FindFunc(tagInfo.Options, func(s string) bool {
+			return s == "-"
+		}); ok || (name == "-" && len(tagInfo.Options) == 0) {
+			continue
+		}
+
+		if _, ok := xslices.FindFunc(tagInfo.Options, func(s string) bool {
 			return s == "omitempty"
 		}); ok {
 			if reflect.DeepEqual(value.Interface(), reflect.Zero(val.Field(i).Type()).Interface()) {
@@ -128,7 +170,7 @@ func (h *handler) handleStruct(obj any) any {
 			value = value.Elem()
 		}
 		if value.Kind() == reflect.Struct || value.Kind() == reflect.Map {
-			if _, ok := xslices.FindFunc(tagOpts, func(s string) bool {
+			if _, ok := xslices.FindFunc(tagInfo.Options, func(s string) bool {
 				return s == "inline"
 			}); ok {
 				if nestedValues, ok := h.handle(value.Interface()).(map[string]any); ok {
@@ -182,12 +224,15 @@ func (h *handler) handleSlice(obj any) any {
 // It checks for the "json" and "yaml" tags in that order.
 // If one tag is empty, it will return the other tag.
 // If both tags are empty, it returns an empty string and an empty slice.
-func (h *handler) getTag(field reflect.StructField) (string, []string) {
+func (h *handler) getTag(field reflect.StructField) (*tagWrapper, error) {
 	for _, category := range h.tags {
 		if tag := field.Tag.Get(category); tag != "" {
 			splitTag := strings.Split(tag, ",")
-			return splitTag[0], splitTag[1:]
+			return &tagWrapper{
+				Name:    splitTag[0],
+				Options: splitTag[1:],
+			}, nil
 		}
 	}
-	return "", []string{}
+	return nil, fmt.Errorf("no tag of %s found for field %s", strings.Join(h.tags, ", "), field.Name)
 }

--- a/xstructs/map.go
+++ b/xstructs/map.go
@@ -14,7 +14,7 @@ var tagCategories = []string{"json", "yaml"}
 // WithTags allows you to specify custom tag categories to check for.
 // It can be used to override the default "json" and "yaml" tags.
 // The tags are checked in the order they are provided.
-func WithTags(tags ...string) ToMapOptions {
+func WithTags(tags ...string) ToMapOption {
 	return func(h *handler) {
 		h.tags = tags
 	}
@@ -22,14 +22,14 @@ func WithTags(tags ...string) ToMapOptions {
 
 // WithAllowNoTags allows you to specify whether to allow fields without tags.
 // If used, fields without tags will be included in the output map.
-func WithAllowNoTags() ToMapOptions {
+func WithAllowNoTags() ToMapOption {
 	return func(h *handler) {
 		h.allowNoTags = true
 	}
 }
 
-// ToMapOptions is a function that modifies the handler.
-type ToMapOptions func(*handler)
+// ToMapOption is a function that modifies the handler.
+type ToMapOption func(*handler)
 
 // handler is a struct that contains the options for the ToMap function.
 // It contains a list of tags to check for and a flag to allow fields
@@ -53,7 +53,7 @@ type tagWrapper struct {
 // It also initializes the allowNoTags flag to false.
 // It can be modified using the ToMapOptions functions.
 // It returns a pointer to the handler.
-func newHandler(opts ...ToMapOptions) *handler {
+func newHandler(opts ...ToMapOption) *handler {
 	h := &handler{
 		tags:        tagCategories,
 		allowNoTags: false,
@@ -76,7 +76,7 @@ func newHandler(opts ...ToMapOptions) *handler {
 //
 // If the input is nil, it returns nil.
 // If the input is not a struct or map, it returns an error.
-func ToMap(obj any, opts ...ToMapOptions) (map[string]any, error) {
+func ToMap(obj any, opts ...ToMapOption) (map[string]any, error) {
 	handler := newHandler(opts...)
 
 	if obj == nil {

--- a/xstructs/map.go
+++ b/xstructs/map.go
@@ -68,7 +68,8 @@ func newHandler(opts ...ToMapOptions) *handler {
 
 // ToMap converts a struct or map to a map[string]any.
 // It handles nested structs, maps, and slices.
-// It uses the "json" and "yaml" tags to determine the key names.
+// By default, it uses the "json" and "yaml" tags
+// to determine the key names in that order.
 // It respects the `omitempty` tag for fields.
 // It respects the `inline` tag for nested structs.
 // It respects the `-` tag to omit fields.
@@ -228,6 +229,10 @@ func (h *handler) getTag(field reflect.StructField) (*tagWrapper, error) {
 	for _, category := range h.tags {
 		if tag := field.Tag.Get(category); tag != "" {
 			splitTag := strings.Split(tag, ",")
+			// Test if tag is solitary comma, i.e. `json:","`
+			if splitTag[0] == "" && len(splitTag[1]) == 0 {
+				return nil, fmt.Errorf("no tag of %s found for field %s", strings.Join(h.tags, ", "), field.Name)
+			}
 			return &tagWrapper{
 				Name:    splitTag[0],
 				Options: splitTag[1:],

--- a/xstructs/map.go
+++ b/xstructs/map.go
@@ -13,7 +13,7 @@ var tagCategories = []string{"json", "yaml"}
 
 func WithTags(tags ...string) toMapOptions {
 	return func(h *handler) {
-		h.tags = append(h.tags, tags...)
+		h.tags = tags
 	}
 }
 

--- a/xstructs/map_test.go
+++ b/xstructs/map_test.go
@@ -13,7 +13,7 @@ func TestToMap(t *testing.T) {
 	tests := []struct {
 		name     string
 		data     any
-		opts     []xstructs.ToMapOptions
+		opts     []xstructs.ToMapOption
 		expected map[string]any
 		wantErr  bool
 	}{
@@ -278,7 +278,7 @@ func TestToMap(t *testing.T) {
 				},
 				E: []string{"one", "two"},
 			},
-			opts: []xstructs.ToMapOptions{
+			opts: []xstructs.ToMapOption{
 				xstructs.WithTags("yaml", "json"),
 			},
 			expected: map[string]any{
@@ -310,7 +310,7 @@ func TestToMap(t *testing.T) {
 				},
 				E: []string{"one", "two"},
 			},
-			opts: []xstructs.ToMapOptions{
+			opts: []xstructs.ToMapOption{
 				xstructs.WithTags("custom"),
 			},
 			expected: map[string]any{},
@@ -325,7 +325,7 @@ func TestToMap(t *testing.T) {
 				A: 1,
 				B: "test",
 			},
-			opts: []xstructs.ToMapOptions{
+			opts: []xstructs.ToMapOption{
 				xstructs.WithAllowNoTags(),
 			},
 			expected: map[string]any{

--- a/xstructs/map_test.go
+++ b/xstructs/map_test.go
@@ -373,6 +373,16 @@ func TestToMap(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "comma in tag",
+			data: struct {
+				A int `json:","`
+			}{
+				A: 1,
+			},
+			expected: map[string]any{},
+			wantErr:  false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Adding support for custom tag ordering, allowing consumers to decide which tags should be considered and in which order.
Previously, consumers using e.g.
```
type A struct {
    B string `json:"-" yaml:"b"`
}
```
would see `B` omitted, as it prioritised JSON tags over YAML tags.

Now consumers can use:
```
xstructs.ToMap(s, xstructs.WithTags([]string{"yaml", "json"})
```
To prioritise YAML tags over JSON tags. 
